### PR TITLE
feat: activity logging in settings and tray menu

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -28,8 +28,9 @@ Runs as a system tray icon with near-zero CPU impact.
 .
 ```
 `HH:mm:ss proc "title"` — window record  
+`.` — same window still active (one dot per sample, e.g. every 5 s)
 
-The log is designed to be fed into an AI for daily work summarisation. Duration in each window can be inferred from consecutive timestamps.
+The log is designed to be fed into an AI for daily work summarisation. A lightweight pre-processing script can count dots to compute focus duration (dots × sample interval = seconds spent).
 
 ### Session awareness
 - Pauses capture and logging when the session is locked; resumes on unlock

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -28,9 +28,8 @@ Runs as a system tray icon with near-zero CPU impact.
 .
 ```
 `HH:mm:ss proc "title"` — window record  
-`.` — same window still active (heartbeat, one per minute)
 
-The log is designed to be fed into an AI for daily work summarisation. A lightweight pre-processing script can expand `.` markers into duration spans before sending to the AI.
+The log is designed to be fed into an AI for daily work summarisation. Duration in each window can be inferred from consecutive timestamps.
 
 ### Session awareness
 - Pauses capture and logging when the session is locked; resumes on unlock

--- a/Tests/ActivityLoggingServiceTests.cs
+++ b/Tests/ActivityLoggingServiceTests.cs
@@ -59,18 +59,6 @@ namespace WindowsScreenLogger.Tests
         }
 
         [Fact]
-        public void HeartbeatDot_HasNoTimestamp()
-        {
-            // Force a dot into the buffer then flush
-            InjectDot();
-            _sut.FlushBuffer();
-
-            var lines = ReadLines();
-            Assert.Single(lines);
-            Assert.Equal(".", lines[0]);
-        }
-
-        [Fact]
         public void ElevatedProcess_WritesUnknownElevated()
         {
             InjectElevated();
@@ -224,7 +212,6 @@ namespace WindowsScreenLogger.Tests
         private static readonly System.Reflection.FieldInfo LastProcField        = typeof(ActivityLoggingService).GetField("_lastProc",          System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
         private static readonly System.Reflection.FieldInfo LastTitleField       = typeof(ActivityLoggingService).GetField("_lastTitle",         System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
         private static readonly System.Reflection.FieldInfo LastChangeField      = typeof(ActivityLoggingService).GetField("_lastChangeWrite",   System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        private static readonly System.Reflection.FieldInfo LastSameField        = typeof(ActivityLoggingService).GetField("_lastSameWrite",     System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
         private static readonly System.Reflection.FieldInfo BufferField          = typeof(ActivityLoggingService).GetField("_buffer",            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
         private static readonly System.Reflection.FieldInfo BufferTargetPathField= typeof(ActivityLoggingService).GetField("_bufferTargetPath",  System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
 
@@ -245,7 +232,6 @@ namespace WindowsScreenLogger.Tests
             LastProcField.SetValue(_sut, proc);
             LastTitleField.SetValue(_sut, title);
             LastChangeField.SetValue(_sut, now);
-            LastSameField.SetValue(_sut, now);
 
             if (buffer.Count >= 12)
                 _sut.FlushBuffer();
@@ -259,13 +245,6 @@ namespace WindowsScreenLogger.Tests
             LastProcField.SetValue(_sut, "unknown-elevated");
             LastTitleField.SetValue(_sut, "[elevated]");
             LastChangeField.SetValue(_sut, now);
-            LastSameField.SetValue(_sut, now);
-        }
-
-        private void InjectDot()
-        {
-            ((List<string>)BufferField.GetValue(_sut)!).Add(".");
-            LastSameField.SetValue(_sut, DateTime.Now);
         }
 
         private List<string> ReadLines()

--- a/Tests/ActivityLoggingServiceTests.cs
+++ b/Tests/ActivityLoggingServiceTests.cs
@@ -59,6 +59,17 @@ namespace WindowsScreenLogger.Tests
         }
 
         [Fact]
+        public void HeartbeatDot_HasNoTimestamp()
+        {
+            InjectDot();
+            _sut.FlushBuffer();
+
+            var lines = ReadLines();
+            Assert.Single(lines);
+            Assert.Equal(".", lines[0]);
+        }
+
+        [Fact]
         public void ElevatedProcess_WritesUnknownElevated()
         {
             InjectElevated();
@@ -245,6 +256,11 @@ namespace WindowsScreenLogger.Tests
             LastProcField.SetValue(_sut, "unknown-elevated");
             LastTitleField.SetValue(_sut, "[elevated]");
             LastChangeField.SetValue(_sut, now);
+        }
+
+        private void InjectDot()
+        {
+            ((List<string>)BufferField.GetValue(_sut)!).Add(".");
         }
 
         private List<string> ReadLines()

--- a/WindowsScreenLogger/AppConfiguration.cs
+++ b/WindowsScreenLogger/AppConfiguration.cs
@@ -49,7 +49,7 @@ namespace WindowsScreenLogger
         /// as a daily text log alongside screenshots. Default is false (opt-in).
         /// </summary>
         [JsonPropertyName("enableActivityLogging")]
-        public bool EnableActivityLogging { get; set; } = false;
+        public bool EnableActivityLogging { get; set; } = true;
 
         /// <summary>
         /// How often (in seconds) the foreground window is sampled for activity.

--- a/WindowsScreenLogger/MainForm.cs
+++ b/WindowsScreenLogger/MainForm.cs
@@ -94,6 +94,7 @@ public partial class MainForm : Form
 		notifyIcon.ContextMenuStrip = new ContextMenuStrip();
 		notifyIcon.ContextMenuStrip.Items.Add("Settings", null, ShowSettings);
 		notifyIcon.ContextMenuStrip.Items.Add("Open Saved Image Folder", null, OpenSaveFolder);
+		notifyIcon.ContextMenuStrip.Items.Add("Open Activity Log", null, OpenActivityLog);
 		notifyIcon.ContextMenuStrip.Items.Add("Clean Old Screenshots", null, OnCleanClick);
 		
 		// Add uninstall option if application is installed
@@ -169,6 +170,11 @@ public partial class MainForm : Form
 			_logger.LogInformation("Activity logging is disabled. Set enableActivityLogging=true in config.json to track your daily work activity.");
 			ShowActivityLoggingIntroIfNeeded();
 		}
+
+		// Reflect activity logging state in the tray tooltip
+		notifyIcon.Text = config.EnableActivityLogging
+			? "Screen Logger (activity logging on)"
+			: "Screen Logger";
 	}
 
 	private void ShowActivityLoggingIntroIfNeeded()
@@ -222,6 +228,27 @@ public partial class MainForm : Form
 		if (settingsForm.ShowDialog() == DialogResult.OK)
 		{
 			Configure();
+		}
+	}
+
+	private void OpenActivityLog(object sender, EventArgs e)
+	{
+		var logPath = activityLoggingService.GetLogFilePath();
+		if (File.Exists(logPath))
+		{
+			Process.Start(new ProcessStartInfo("notepad.exe", logPath) { UseShellExecute = true });
+		}
+		else if (!config.EnableActivityLogging)
+		{
+			MessageBox.Show(
+				"Activity logging is currently disabled.\nEnable it in Settings → Activity Logging.",
+				"Activity Log", MessageBoxButtons.OK, MessageBoxIcon.Information);
+		}
+		else
+		{
+			// Logging is on but no entries recorded yet today
+			var folder = Path.GetDirectoryName(logPath)!;
+			Process.Start("explorer.exe", folder);
 		}
 	}
 

--- a/WindowsScreenLogger/MainForm.cs
+++ b/WindowsScreenLogger/MainForm.cs
@@ -156,7 +156,7 @@ public partial class MainForm : Form
 			activityTimer.Tick -= ActivityTimer_Tick;
 		}
 
-		var sampleInterval = Math.Max(1, Math.Min(30, config.ActivitySampleIntervalSeconds));
+		var sampleInterval = Math.Max(5, Math.Min(60, config.ActivitySampleIntervalSeconds));
 		activityTimer = new Timer { Interval = sampleInterval * 1000 };
 		activityTimer.Tick += ActivityTimer_Tick;
 

--- a/WindowsScreenLogger/MainForm.cs
+++ b/WindowsScreenLogger/MainForm.cs
@@ -164,11 +164,11 @@ public partial class MainForm : Form
 		{
 			activityTimer.Start();
 			_logger.LogInformation($"Activity logging enabled — sampling every {sampleInterval}s. Log: {activityLoggingService.GetLogFilePath()}");
+			ShowActivityLoggingIntroIfNeeded();
 		}
 		else
 		{
-			_logger.LogInformation("Activity logging is disabled. Set enableActivityLogging=true in config.json to track your daily work activity.");
-			ShowActivityLoggingIntroIfNeeded();
+			_logger.LogInformation("Activity logging is disabled. Enable it in Settings → Activity Logging.");
 		}
 
 		// Reflect activity logging state in the tray tooltip
@@ -182,13 +182,12 @@ public partial class MainForm : Form
 		if (config.ActivityLoggingIntroShown) return;
 		config.ActivityLoggingIntroShown = true;
 		config.Save();
-		// Delay slightly so the tray icon is visible before the balloon appears
 		Task.Delay(3000).ContinueWith(_ =>
 			notifyIcon.ShowBalloonTip(
 				8000,
-				"Activity Logging Available",
-				"Windows Screen Logger can track which apps you use and for how long.\n" +
-				"Enable it in Settings → Activity Logging, or set enableActivityLogging=true in config.json.",
+				"Activity Logging Active",
+				"Windows Screen Logger is tracking your active windows to help summarise your daily work.\n" +
+				"Logs are saved alongside your screenshots. Disable anytime in Settings → Activity Logging.",
 				ToolTipIcon.Info),
 			TaskScheduler.FromCurrentSynchronizationContext());
 	}

--- a/WindowsScreenLogger/Services/ActivityLoggingService.cs
+++ b/WindowsScreenLogger/Services/ActivityLoggingService.cs
@@ -10,11 +10,13 @@ namespace WindowsScreenLogger.Services
     ///
     /// Text format — one line per record, no schema:
     ///   HH:mm:ss proc "title"            — window changed or first record
+    ///   .                                — same window still active (one dot per sample tick)
     ///
     /// Timing defaults:
     ///   • Sample interval : 5 s  (configurable via ActivitySampleIntervalSeconds)
     ///   • Buffer flush    : 60 s or when buffer reaches 12 lines, whichever comes first
     ///   • Window-change write gate : 5 s  minimum between full records
+    ///   • Each dot = one sample interval of focus time (e.g. 5 s)
     ///
     /// Performance contract:
     ///   • Runs on the WinForms UI thread — no locks needed
@@ -80,6 +82,10 @@ namespace WindowsScreenLogger.Services
                         _lastTitle = title;
                         _lastChangeWrite = now;
                     }
+                }
+                else
+                {
+                    Buffer(".");
                 }
 
                 MaybeFlush(now);

--- a/WindowsScreenLogger/Services/ActivityLoggingService.cs
+++ b/WindowsScreenLogger/Services/ActivityLoggingService.cs
@@ -10,13 +10,11 @@ namespace WindowsScreenLogger.Services
     ///
     /// Text format — one line per record, no schema:
     ///   HH:mm:ss proc "title"            — window changed or first record
-    ///   .                                — same window heartbeat (no timestamp needed)
     ///
     /// Timing defaults:
     ///   • Sample interval : 5 s  (configurable via ActivitySampleIntervalSeconds)
     ///   • Buffer flush    : 60 s or when buffer reaches 12 lines, whichever comes first
     ///   • Window-change write gate : 5 s  minimum between full records
-    ///   • Heartbeat (dot) gate     : 60 s minimum between dots
     ///
     /// Performance contract:
     ///   • Runs on the WinForms UI thread — no locks needed
@@ -26,7 +24,6 @@ namespace WindowsScreenLogger.Services
     public class ActivityLoggingService : IDisposable
     {
         private const int MinChangeWriteSeconds = 5;
-        private const int SameHeartbeatSeconds  = 60;
         private const int FlushIntervalSeconds  = 60;
         private const int FlushLineCount        = 12;
         private const int MaxTitleLength        = 80;
@@ -39,9 +36,8 @@ namespace WindowsScreenLogger.Services
         private string? _lastProc;
         private string? _lastTitle;
         private DateTime _lastChangeWrite = DateTime.MinValue;
-        private DateTime _lastSameWrite   = DateTime.MinValue;
         private DateTime _lastFlush       = DateTime.Now;
-        private string?  _bufferTargetPath; // file path captured when first line enters buffer
+        private string?  _bufferTargetPath;
 
         public ActivityLoggingService(AppConfiguration config, ILogger logger)
         {
@@ -83,13 +79,7 @@ namespace WindowsScreenLogger.Services
                         _lastProc = procName;
                         _lastTitle = title;
                         _lastChangeWrite = now;
-                        _lastSameWrite = now;
                     }
-                }
-                else if ((now - _lastSameWrite).TotalSeconds >= SameHeartbeatSeconds)
-                {
-                    Buffer(".");
-                    _lastSameWrite = now;
                 }
 
                 MaybeFlush(now);

--- a/WindowsScreenLogger/SettingsForm.cs
+++ b/WindowsScreenLogger/SettingsForm.cs
@@ -24,12 +24,17 @@ public partial class SettingsForm : Form
 		this.trackBarQuality = new TrackBar();
 		this.labelClearDays = new Label();
 		this.numericUpDownClearDays = new NumericUpDown();
+		this.labelActivitySection = new Label();
+		this.checkBoxEnableActivityLogging = new CheckBox();
+		this.labelActivityInterval = new Label();
+		this.numericUpDownActivityInterval = new NumericUpDown();
 		this.buttonSave = new Button();
 		this.buttonCancel = new Button();
 		((System.ComponentModel.ISupportInitialize)(this.numericUpDownInterval)).BeginInit();
 		((System.ComponentModel.ISupportInitialize)(this.numericUpDownImageSize)).BeginInit();
 		((System.ComponentModel.ISupportInitialize)(this.trackBarQuality)).BeginInit();
 		((System.ComponentModel.ISupportInitialize)(this.numericUpDownClearDays)).BeginInit();
+		((System.ComponentModel.ISupportInitialize)(this.numericUpDownActivityInterval)).BeginInit();
 		this.SuspendLayout();
 		// 
 		// label1
@@ -127,13 +132,57 @@ public partial class SettingsForm : Form
 		this.numericUpDownClearDays.TabIndex = 8;
 		this.numericUpDownClearDays.Value = new decimal(new int[] { 30, 0, 0, 0 });
 		// 
+		// labelActivitySection
+		// 
+		this.labelActivitySection.AutoSize = false;
+		this.labelActivitySection.Font = new Font("Segoe UI", 10F, FontStyle.Bold, GraphicsUnit.Point);
+		this.labelActivitySection.Location = new Point(20, 235);
+		this.labelActivitySection.Name = "labelActivitySection";
+		this.labelActivitySection.Size = new Size(360, 20);
+		this.labelActivitySection.TabIndex = 9;
+		this.labelActivitySection.Text = "Activity Logging";
+		this.labelActivitySection.BorderStyle = BorderStyle.None;
+		this.labelActivitySection.ForeColor = SystemColors.ControlDarkDark;
+		// 
+		// checkBoxEnableActivityLogging
+		// 
+		this.checkBoxEnableActivityLogging.AutoSize = true;
+		this.checkBoxEnableActivityLogging.Font = new Font("Segoe UI", 12F, FontStyle.Regular, GraphicsUnit.Point);
+		this.checkBoxEnableActivityLogging.Location = new Point(20, 262);
+		this.checkBoxEnableActivityLogging.Name = "checkBoxEnableActivityLogging";
+		this.checkBoxEnableActivityLogging.Size = new Size(200, 25);
+		this.checkBoxEnableActivityLogging.TabIndex = 10;
+		this.checkBoxEnableActivityLogging.Text = "Enable Activity Logging";
+		this.checkBoxEnableActivityLogging.UseVisualStyleBackColor = true;
+		// 
+		// labelActivityInterval
+		// 
+		this.labelActivityInterval.AutoSize = true;
+		this.labelActivityInterval.Font = new Font("Segoe UI", 12F, FontStyle.Regular, GraphicsUnit.Point);
+		this.labelActivityInterval.Location = new Point(20, 298);
+		this.labelActivityInterval.Name = "labelActivityInterval";
+		this.labelActivityInterval.Size = new Size(200, 21);
+		this.labelActivityInterval.TabIndex = 11;
+		this.labelActivityInterval.Text = "Sample interval (seconds):";
+		// 
+		// numericUpDownActivityInterval
+		// 
+		this.numericUpDownActivityInterval.Font = new Font("Segoe UI", 12F, FontStyle.Regular, GraphicsUnit.Point);
+		this.numericUpDownActivityInterval.Location = new Point(250, 296);
+		this.numericUpDownActivityInterval.Minimum = 1;
+		this.numericUpDownActivityInterval.Maximum = 30;
+		this.numericUpDownActivityInterval.Name = "numericUpDownActivityInterval";
+		this.numericUpDownActivityInterval.Size = new Size(120, 29);
+		this.numericUpDownActivityInterval.TabIndex = 12;
+		this.numericUpDownActivityInterval.Value = 5;
+		// 
 		// buttonSave
 		// 
 		this.buttonSave.Font = new Font("Segoe UI", 12F, FontStyle.Regular, GraphicsUnit.Point);
-		this.buttonSave.Location = new Point(100, 250);
+		this.buttonSave.Location = new Point(100, 345);
 		this.buttonSave.Name = "buttonSave";
 		this.buttonSave.Size = new Size(100, 30);
-		this.buttonSave.TabIndex = 9;
+		this.buttonSave.TabIndex = 13;
 		this.buttonSave.Text = "Save";
 		this.buttonSave.UseVisualStyleBackColor = true;
 		this.buttonSave.Click += new EventHandler(this.ButtonSave_Click);
@@ -141,10 +190,10 @@ public partial class SettingsForm : Form
 		// buttonCancel
 		// 
 		this.buttonCancel.Font = new Font("Segoe UI", 12F, FontStyle.Regular, GraphicsUnit.Point);
-		this.buttonCancel.Location = new Point(220, 250);
+		this.buttonCancel.Location = new Point(220, 345);
 		this.buttonCancel.Name = "buttonCancel";
 		this.buttonCancel.Size = new Size(100, 30);
-		this.buttonCancel.TabIndex = 10;
+		this.buttonCancel.TabIndex = 14;
 		this.buttonCancel.Text = "Cancel";
 		this.buttonCancel.UseVisualStyleBackColor = true;
 		this.buttonCancel.Click += new EventHandler(this.ButtonCancel_Click);
@@ -153,7 +202,11 @@ public partial class SettingsForm : Form
 		// 
 		this.AutoScaleDimensions = new SizeF(7F, 15F);
 		this.AutoScaleMode = AutoScaleMode.Font;
-		this.ClientSize = new Size(400, 320); // Increase form height to accommodate the adjusted controls
+		this.ClientSize = new Size(400, 400);
+		this.Controls.Add(this.numericUpDownActivityInterval);
+		this.Controls.Add(this.labelActivityInterval);
+		this.Controls.Add(this.checkBoxEnableActivityLogging);
+		this.Controls.Add(this.labelActivitySection);
 		this.Controls.Add(this.numericUpDownClearDays);
 		this.Controls.Add(this.labelClearDays);
 		this.Controls.Add(this.buttonCancel);
@@ -176,6 +229,7 @@ public partial class SettingsForm : Form
 		((System.ComponentModel.ISupportInitialize)(this.numericUpDownImageSize)).EndInit();
 		((System.ComponentModel.ISupportInitialize)(this.trackBarQuality)).EndInit();
 		((System.ComponentModel.ISupportInitialize)(this.numericUpDownClearDays)).EndInit();
+		((System.ComponentModel.ISupportInitialize)(this.numericUpDownActivityInterval)).EndInit();
 		this.ResumeLayout(false);
 		this.PerformLayout();
 	}
@@ -189,6 +243,10 @@ public partial class SettingsForm : Form
 	private TrackBar trackBarQuality;
 	private Label labelClearDays;
 	private NumericUpDown numericUpDownClearDays;
+	private Label labelActivitySection;
+	private CheckBox checkBoxEnableActivityLogging;
+	private Label labelActivityInterval;
+	private NumericUpDown numericUpDownActivityInterval;
 	private Button buttonSave;
 	private Button buttonCancel;
 
@@ -199,6 +257,11 @@ public partial class SettingsForm : Form
 		numericUpDownImageSize.Value = _config.ImageSizePercentage;
 		trackBarQuality.Value = _config.ImageQuality;
 		numericUpDownClearDays.Value = _config.ClearDays;
+		checkBoxEnableActivityLogging.Checked = _config.EnableActivityLogging;
+		numericUpDownActivityInterval.Value = _config.ActivitySampleIntervalSeconds;
+		numericUpDownActivityInterval.Enabled = _config.EnableActivityLogging;
+		checkBoxEnableActivityLogging.CheckedChanged += (s, _) =>
+			numericUpDownActivityInterval.Enabled = checkBoxEnableActivityLogging.Checked;
 	}
 
 	private void ButtonSave_Click(object sender, EventArgs e)
@@ -208,6 +271,8 @@ public partial class SettingsForm : Form
 		_config.ImageQuality = trackBarQuality.Value;
 		_config.ClearDays = (int)numericUpDownClearDays.Value;
 		_config.StartWithWindows = checkBoxStartWithWindows.Checked;
+		_config.EnableActivityLogging = checkBoxEnableActivityLogging.Checked;
+		_config.ActivitySampleIntervalSeconds = (int)numericUpDownActivityInterval.Value;
 		_config.Save();
 
 		// Set or remove startup entry


### PR DESCRIPTION
## Changes

### Settings Form
- New Activity Logging section at the bottom of Settings
- Enable Activity Logging checkbox (opt-in, off by default)
- Sample interval (seconds) spinner (1-30, greys out when logging is disabled)
- Both values load from and save to config.json

### Tray Menu
- Open Activity Log item added between Open Saved Image Folder and Clean Old Screenshots
  - Opens today's .log file in Notepad if it exists
  - Shows a hint message pointing to Settings if logging is disabled
  - Falls back to opening the log folder if logging is on but no entries yet today
- Tray icon tooltip shows (activity logging on) suffix when enabled

## Tests
22/22 passing