### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write   # required to create GitHub Releases
+
+jobs:
+  release:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # Strip leading 'v' from tag → "1.2.0"
+      - name: Extract version
+        id: version
+        shell: pwsh
+        run: echo "number=$('${{ github.ref_name }}'.TrimStart('v'))" >> $env:GITHUB_OUTPUT
+
+      - name: Run tests
+        run: dotnet test Tests/WindowsScreenLogger.Tests.csproj -c Release --logger "console;verbosity=normal"
+
+      - name: Publish WindowsScreenLogger
+        run: |
+          dotnet publish WindowsScreenLogger/WindowsScreenLogger.csproj `
+            -c Release `
+            -p:Version=${{ steps.version.outputs.number }} `
+            -o publish/app
+
+      - name: Publish ActivityLogProcessor
+        run: |
+          dotnet publish ActivityLogProcessor/ActivityLogProcessor.csproj `
+            -c Release `
+            -r win-x64 --self-contained true -p:PublishSingleFile=true `
+            -p:Version=${{ steps.version.outputs.number }} `
+            -o publish/processor
+
+      - name: Package artifacts
+        shell: pwsh
+        run: |
+          Compress-Archive publish/app/*      WindowsScreenLogger-${{ github.ref_name }}-win-x64.zip
+          Compress-Archive publish/processor/* ActivityLogProcessor-${{ github.ref_name }}-win-x64.zip
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            WindowsScreenLogger-${{ github.ref_name }}-win-x64.zip
+            ActivityLogProcessor-${{ github.ref_name }}-win-x64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g. 1.0.0) — no leading v'
+        required: true
+        default: '0.0.0-test'
+      create_release:
+        description: 'Create a GitHub Release? (false = build/test only)'
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: write   # required to create GitHub Releases
@@ -20,11 +31,19 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      # Strip leading 'v' from tag → "1.2.0"
-      - name: Extract version
+      # For tag pushes: strip leading 'v' from tag → "1.2.0"
+      # For manual runs: use the version input directly
+      - name: Resolve version
         id: version
         shell: pwsh
-        run: echo "number=$('${{ github.ref_name }}'.TrimStart('v'))" >> $env:GITHUB_OUTPUT
+        run: |
+          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
+            echo "number=${{ github.event.inputs.version }}" >> $env:GITHUB_OUTPUT
+            echo "ref_name=v${{ github.event.inputs.version }}" >> $env:GITHUB_OUTPUT
+          } else {
+            echo "number=$('${{ github.ref_name }}'.TrimStart('v'))" >> $env:GITHUB_OUTPUT
+            echo "ref_name=${{ github.ref_name }}" >> $env:GITHUB_OUTPUT
+          }
 
       - name: Run tests
         run: dotnet test Tests/WindowsScreenLogger.Tests.csproj -c Release --logger "console;verbosity=normal"
@@ -47,13 +66,23 @@ jobs:
       - name: Package artifacts
         shell: pwsh
         run: |
-          Compress-Archive publish/app/*      WindowsScreenLogger-${{ github.ref_name }}-win-x64.zip
-          Compress-Archive publish/processor/* ActivityLogProcessor-${{ github.ref_name }}-win-x64.zip
+          Compress-Archive publish/app/*      "WindowsScreenLogger-${{ steps.version.outputs.ref_name }}-win-x64.zip"
+          Compress-Archive publish/processor/* "ActivityLogProcessor-${{ steps.version.outputs.ref_name }}-win-x64.zip"
+
+      - name: Upload build artifacts (manual runs)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts-${{ steps.version.outputs.number }}
+          path: '*.zip'
+          retention-days: 7
 
       - name: Create GitHub Release
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true')
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.version.outputs.ref_name }}
           generate_release_notes: true
           files: |
-            WindowsScreenLogger-${{ github.ref_name }}-win-x64.zip
-            ActivityLogProcessor-${{ github.ref_name }}-win-x64.zip
+            WindowsScreenLogger-${{ steps.version.outputs.ref_name }}-win-x64.zip
+            ActivityLogProcessor-${{ steps.version.outputs.ref_name }}-win-x64.zip


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/release.yml`) that automatically builds and publishes a GitHub Release whenever a version tag is pushed.

## How it works

**Trigger:** Push a tag matching `v*.*.*` (e.g. `git tag v1.1.0 && git push origin v1.1.0`)

**Steps:**
1. Runs tests via `dotnet test`
2. Publishes `WindowsScreenLogger` as a self-contained single-file `win-x64` exe (uses existing `.csproj` settings)
3. Publishes `ActivityLogProcessor` as a self-contained single-file `win-x64` exe
4. Zips both artifacts
5. Creates a GitHub Release with both ZIPs attached and auto-generated release notes

## Artifacts produced

- `WindowsScreenLogger-v1.x.x-win-x64.zip`
- `ActivityLogProcessor-v1.x.x-win-x64.zip`

## Notes

- Uses `windows-latest` runner (required for `net10.0-windows` targets)
- Version number is injected from the git tag into both assemblies via `-p:Version=`
- Tests must pass before artifacts are published — a test failure aborts the release
- No secrets needed; uses the workflow's built-in `GITHUB_TOKEN`
