### PR TITLE
Add activity summary generation from tray menu

### DIFF
--- a/ActivityLogProcessor/SummaryFormatter.cs
+++ b/ActivityLogProcessor/SummaryFormatter.cs
@@ -5,6 +5,8 @@ namespace ActivityLogProcessor;
 
 public static class SummaryFormatter
 {
+    private static readonly TimeSpan MarkdownMinimumAppDuration = TimeSpan.FromMinutes(2);
+
     public static string FormatTimeline(ActivitySummary summary, string? dateLabel = null)
     {
         var sb = new StringBuilder();
@@ -63,6 +65,12 @@ public static class SummaryFormatter
     {
         var sb = new StringBuilder();
         var label = dateLabel ?? "Activity Summary";
+        var includedApps = summary.ByApplication
+            .Where(app => app.TotalDuration >= MarkdownMinimumAppDuration)
+            .ToList();
+        var includedProcesses = includedApps
+            .Select(app => app.Process)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         sb.AppendLine($"# Activity Summary — {label}");
         sb.AppendLine();
@@ -71,7 +79,7 @@ public static class SummaryFormatter
         sb.AppendLine();
         sb.AppendLine("| Application | Friendly Name | Total Time |");
         sb.AppendLine("|-------------|---------------|------------|");
-        foreach (var app in summary.ByApplication)
+        foreach (var app in includedApps)
         {
             var duration = FormatDuration(app.TotalDuration);
             var friendly = app.FriendlyName ?? string.Empty;
@@ -83,7 +91,7 @@ public static class SummaryFormatter
         sb.AppendLine();
         sb.AppendLine("| Application | Window Title | Duration |");
         sb.AppendLine("|-------------|--------------|----------|");
-        foreach (var w in summary.TopWindows)
+        foreach (var w in summary.TopWindows.Where(window => includedProcesses.Contains(window.Process)))
         {
             var mins = FormatMinutes(w.TotalDuration);
             sb.AppendLine($"| {w.Process} | {EscapeMarkdown(w.Title)} | {mins} |");

--- a/Tests/ActivityLogProcessorTests.cs
+++ b/Tests/ActivityLogProcessorTests.cs
@@ -451,8 +451,8 @@ public class SummaryFormatterMarkdownTests
     [Fact]
     public void FormatMarkdown_PipeInWindowTitle_IsEscaped()
     {
-        var entries = new[] { MakeEntry("code", "File | tab — VS Code", 2) };
-        var summary = ActivitySummariser.Summarise(entries, sampleIntervalSeconds: 5);
+        var entries = new[] { MakeEntry("code", "File | tab — VS Code", 1) };
+        var summary = ActivitySummariser.Summarise(entries, sampleIntervalSeconds: 60);
         var md = SummaryFormatter.FormatMarkdown(summary, "test");
 
         Assert.Contains(@"File \| tab — VS Code", md);
@@ -461,11 +461,28 @@ public class SummaryFormatterMarkdownTests
     [Fact]
     public void FormatMarkdown_EmptyFriendlyName_LeavesBlankCell()
     {
-        var entries = new[] { MakeEntry("unknownapp99", "Some Window", 0) };
-        var summary = ActivitySummariser.Summarise(entries, sampleIntervalSeconds: 5);
+        var entries = new[] { MakeEntry("unknownapp99", "Some Window", 1) };
+        var summary = ActivitySummariser.Summarise(entries, sampleIntervalSeconds: 60);
         var md = SummaryFormatter.FormatMarkdown(summary, "test");
 
         Assert.Contains("| unknownapp99 |  |", md);
+    }
+
+    [Fact]
+    public void FormatMarkdown_IgnoresAppsUnderTwoMinutes()
+    {
+        var entries = new[]
+        {
+            MakeEntry("code", "Long Task", 1),
+            MakeEntry("notepad", "Short Note", 0),
+        };
+        var summary = ActivitySummariser.Summarise(entries, sampleIntervalSeconds: 60);
+        var md = SummaryFormatter.FormatMarkdown(summary, "test");
+
+        Assert.Contains("| code | Visual Studio Code | 0h 02m |", md);
+        Assert.DoesNotContain("| notepad |", md);
+        Assert.DoesNotContain("Short Note", md);
+        Assert.Contains("**Total tracked:** 0h 03m", md);
     }
 }
 

--- a/Tests/ActivitySummaryServiceTests.cs
+++ b/Tests/ActivitySummaryServiceTests.cs
@@ -82,6 +82,20 @@ public class ActivitySummaryServiceTests : IDisposable
 	}
 
 	[Fact]
+	public void GetPreviousDayLogPath_IgnoresNonActivityLogFiles()
+	{
+		var now = new DateTime(2026, 3, 27, 8, 0, 0);
+		var validLogPath = Path.Combine(_logDir, "2026-03-25.log");
+		var otherLogPath = Path.Combine(_logDir, "application.log");
+		File.WriteAllText(validLogPath, "activity log");
+		File.WriteAllText(otherLogPath, "not an activity log");
+
+		var service = CreateService();
+
+		Assert.Equal(validLogPath, service.GetPreviousDayLogPath(now));
+	}
+
+	[Fact]
 	public async Task GeneratePreviousDaySummaryIfMissingAsync_SkipsWhenSummaryExists()
 	{
 		var now = new DateTime(2026, 3, 27, 8, 0, 0);
@@ -162,6 +176,25 @@ public class ActivitySummaryServiceTests : IDisposable
 		Assert.Equal(ActivitySummaryService.SummaryGenerationStatus.Success, result.Status);
 		Assert.Equal(1, processCallCount);
 		Assert.Equal("replacement summary", File.ReadAllText(outputPath));
+	}
+
+	[Fact]
+	public async Task GenerateSummaryAsync_WithOverwriteExisting_RestoresExistingSummaryOnFailure()
+	{
+		var logPath = Path.Combine(_logDir, "2026-03-26.log");
+		var outputPath = Path.Combine(_outputDir, "2026-03-26.md");
+		File.WriteAllText(logPath, "sample");
+		Directory.CreateDirectory(_outputDir);
+		File.WriteAllText(outputPath, "existing summary");
+
+		var service = CreateService(
+			processorPathResolver: () => "fake-processor.exe",
+			processRunner: (_, _, _) => Task.FromResult(new ActivitySummaryService.ProcessExecutionResult(1, string.Empty, "processor failed")));
+
+		var result = await service.GenerateSummaryAsync(logPath, overwriteExisting: true);
+
+		Assert.Equal(ActivitySummaryService.SummaryGenerationStatus.Failed, result.Status);
+		Assert.Equal("existing summary", File.ReadAllText(outputPath));
 	}
 
 	private ActivitySummaryService CreateService(

--- a/Tests/ActivitySummaryServiceTests.cs
+++ b/Tests/ActivitySummaryServiceTests.cs
@@ -1,0 +1,192 @@
+using WindowsActivityLogger;
+using WindowsActivityLogger.Services;
+using Xunit;
+
+namespace WindowsActivityLogger.Tests;
+
+public class ActivitySummaryServiceTests : IDisposable
+{
+	private readonly string _tempDir;
+	private readonly string _logDir;
+	private readonly string _outputDir;
+	private readonly AppConfiguration _config;
+	private readonly NoopLogger _logger = new();
+
+	public ActivitySummaryServiceTests()
+	{
+		_tempDir = Path.Combine(Path.GetTempPath(), "ActivitySummaryTests_" + Guid.NewGuid());
+		_logDir = Path.Combine(_tempDir, "logs");
+		_outputDir = Path.Combine(_tempDir, "summary");
+		Directory.CreateDirectory(_logDir);
+
+		_config = new AppConfiguration
+		{
+			CustomSavePath = _logDir,
+			ActivitySummaryOutputDir = _outputDir,
+			ActivitySampleIntervalSeconds = 5,
+		};
+	}
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_tempDir, recursive: true); } catch { }
+	}
+
+	[Fact]
+	public void GetSummaryOutputPath_UsesLogFileName()
+	{
+		var service = CreateService();
+		var outputPath = service.GetSummaryOutputPath(Path.Combine(_logDir, "2026-03-26.log"), _outputDir);
+
+		Assert.Equal(Path.Combine(_outputDir, "2026-03-26.md"), outputPath);
+	}
+
+	[Fact]
+	public void GetPreviousDayLogPath_ReturnsExactPreviousDayFile()
+	{
+		var previousDay = new DateTime(2026, 3, 27, 8, 0, 0);
+		var expectedPath = Path.Combine(_logDir, "2026-03-26.log");
+		File.WriteAllText(expectedPath, "sample");
+
+		var service = CreateService();
+
+		Assert.Equal(expectedPath, service.GetPreviousDayLogPath(previousDay));
+	}
+
+	[Fact]
+	public void GetPreviousDayLogPath_FallsBackToLatestAvailableLogBeforeToday()
+	{
+		var now = new DateTime(2026, 3, 27, 8, 0, 0);
+		var olderPath = Path.Combine(_logDir, "2026-03-20.log");
+		var latestPath = Path.Combine(_logDir, "2026-03-25.log");
+		File.WriteAllText(olderPath, "older");
+		File.WriteAllText(latestPath, "latest available before today");
+
+		var service = CreateService();
+
+		Assert.Equal(latestPath, service.GetPreviousDayLogPath(now));
+	}
+
+	[Fact]
+	public void GetPreviousDayLogPath_DoesNotUseTodayLogWhenYesterdayIsMissing()
+	{
+		var now = new DateTime(2026, 3, 27, 8, 0, 0);
+		var lastWeekPath = Path.Combine(_logDir, "2026-03-19.log");
+		var todayPath = Path.Combine(_logDir, "2026-03-27.log");
+		File.WriteAllText(lastWeekPath, "last week");
+		File.WriteAllText(todayPath, "today");
+
+		var service = CreateService();
+
+		Assert.Equal(lastWeekPath, service.GetPreviousDayLogPath(now));
+	}
+
+	[Fact]
+	public async Task GeneratePreviousDaySummaryIfMissingAsync_SkipsWhenSummaryExists()
+	{
+		var now = new DateTime(2026, 3, 27, 8, 0, 0);
+		var logPath = Path.Combine(_logDir, "2026-03-26.log");
+		var outputPath = Path.Combine(_outputDir, "2026-03-26.md");
+		Directory.CreateDirectory(_outputDir);
+		File.WriteAllText(logPath, "sample");
+		File.WriteAllText(outputPath, "existing summary");
+
+		var service = CreateService();
+		var result = await service.GeneratePreviousDaySummaryIfMissingAsync(now);
+
+		Assert.Equal(ActivitySummaryService.SummaryGenerationStatus.AlreadyExists, result.Status);
+		Assert.Equal(outputPath, result.OutputPath);
+	}
+
+	[Fact]
+	public async Task GenerateSummaryAsync_InvokesProcessorWithConfiguredPaths()
+	{
+		var logPath = Path.Combine(_logDir, "2026-03-26.log");
+		File.WriteAllText(logPath, "sample");
+		string? runnerFileName = null;
+		IReadOnlyList<string>? runnerArgs = null;
+
+		var service = CreateService(
+			processorPathResolver: () => "fake-processor.exe",
+			processRunner: (fileName, args, _) =>
+			{
+				runnerFileName = fileName;
+				runnerArgs = args;
+				Directory.CreateDirectory(_outputDir);
+				File.WriteAllText(Path.Combine(_outputDir, "2026-03-26.md"), "generated summary");
+				return Task.FromResult(new ActivitySummaryService.ProcessExecutionResult(0, string.Empty, string.Empty));
+			});
+
+		var result = await service.GenerateSummaryAsync(logPath);
+
+		Assert.Equal(ActivitySummaryService.SummaryGenerationStatus.Success, result.Status);
+		Assert.Equal("fake-processor.exe", runnerFileName);
+		Assert.NotNull(runnerArgs);
+		Assert.Equal(new[] { "--logpath", logPath, "--interval", "5", "--out-dir", _outputDir }, runnerArgs!.ToArray());
+	}
+
+	[Fact]
+	public async Task GenerateSummaryAsync_ReturnsMissingOutputDirectory_WhenNotConfigured()
+	{
+		var logPath = Path.Combine(_logDir, "2026-03-26.log");
+		File.WriteAllText(logPath, "sample");
+		_config.ActivitySummaryOutputDir = null;
+
+		var service = CreateService();
+		var result = await service.GenerateSummaryAsync(logPath);
+
+		Assert.Equal(ActivitySummaryService.SummaryGenerationStatus.MissingOutputDirectory, result.Status);
+	}
+
+	[Fact]
+	public async Task GenerateSummaryAsync_WithOverwriteExisting_ReplacesExistingSummary()
+	{
+		var logPath = Path.Combine(_logDir, "2026-03-26.log");
+		var outputPath = Path.Combine(_outputDir, "2026-03-26.md");
+		File.WriteAllText(logPath, "sample");
+		Directory.CreateDirectory(_outputDir);
+		File.WriteAllText(outputPath, "existing summary");
+		var processCallCount = 0;
+
+		var service = CreateService(
+			processorPathResolver: () => "fake-processor.exe",
+			processRunner: (_, _, _) =>
+			{
+				processCallCount++;
+				File.WriteAllText(outputPath, "replacement summary");
+				return Task.FromResult(new ActivitySummaryService.ProcessExecutionResult(0, string.Empty, string.Empty));
+			});
+
+		var result = await service.GenerateSummaryAsync(logPath, overwriteExisting: true);
+
+		Assert.Equal(ActivitySummaryService.SummaryGenerationStatus.Success, result.Status);
+		Assert.Equal(1, processCallCount);
+		Assert.Equal("replacement summary", File.ReadAllText(outputPath));
+	}
+
+	private ActivitySummaryService CreateService(
+		Func<string>? processorPathResolver = null,
+		Func<string, IReadOnlyList<string>, CancellationToken, Task<ActivitySummaryService.ProcessExecutionResult>>? processRunner = null)
+	{
+		return new ActivitySummaryService(_config, _logger, processorPathResolver, processRunner);
+	}
+
+	private sealed class NoopLogger : ILogger
+	{
+		public void Initialize(bool enableLogging = false, string logLevel = "Information") { }
+		public void LogTrace(string message) { }
+		public void LogDebug(string message) { }
+		public void LogInformation(string message) { }
+		public void LogWarning(string message) { }
+		public void LogError(string message) { }
+		public void LogCritical(string message) { }
+		public void LogException(Exception exception, string? context = null) { }
+		public void LogCommandLineArgs(string[] args) { }
+		public void LogUninstallOperation(string operation, bool success, string? details = null) { }
+		public void LogRegistryOperation(string operation, string key, bool success, string? details = null) { }
+		public string? GetLogFilePath() => null;
+		public void CleanupOldLogs(int daysToKeep = 7) { }
+		public void LogStartup() { }
+		public void LogShutdown() { }
+	}
+}

--- a/WindowsActivityLogger/MainForm.cs
+++ b/WindowsActivityLogger/MainForm.cs
@@ -23,6 +23,7 @@ public partial class MainForm : Form
 	private readonly ScreenshotService screenshotService;
 	private readonly CleanupService cleanupService;
 	private readonly ActivityLoggingService activityLoggingService;
+	private readonly ActivitySummaryService activitySummaryService;
 
 	public MainForm(AppConfiguration? configuration = null, ScreenshotService? screenshot = null, CleanupService? cleanup = null, ILogger? logger = null, bool postInstall = false)
 	{
@@ -32,6 +33,7 @@ public partial class MainForm : Form
 		screenshotService = screenshot ?? new ScreenshotService(config, _logger);
 		cleanupService = cleanup ?? new CleanupService(config, _logger);
 		activityLoggingService = new ActivityLoggingService(config, _logger);
+		activitySummaryService = new ActivitySummaryService(config, _logger);
 		
 		InitializeComponent();
 		Configure();
@@ -95,6 +97,7 @@ public partial class MainForm : Form
 		notifyIcon.ContextMenuStrip.Items.Add("Settings", null, ShowSettings);
 		notifyIcon.ContextMenuStrip.Items.Add("Open Saved Image Folder", null, OpenSaveFolder);
 		notifyIcon.ContextMenuStrip.Items.Add("Open Activity Log", null, OpenActivityLog);
+		notifyIcon.ContextMenuStrip.Items.Add("Generate Activity Summary...", null, GenerateActivitySummaryAsync);
 		notifyIcon.ContextMenuStrip.Items.Add("Clean Old Screenshots", null, OnCleanClick);
 		
 		// Add uninstall option if application is installed
@@ -130,6 +133,8 @@ public partial class MainForm : Form
 				"Installation complete! The activity logger is now running.",
 				ToolTipIcon.Info);
 		}
+
+		_ = GeneratePreviousDaySummaryOnStartupAsync();
 	}
 
 	private void Configure()
@@ -257,6 +262,120 @@ public partial class MainForm : Form
 			// Logging is on but no entries recorded yet today
 			var folder = Path.GetDirectoryName(logPath)!;
 			Process.Start("explorer.exe", folder);
+		}
+	}
+
+	private async void GenerateActivitySummaryAsync(object? sender, EventArgs e)
+	{
+		var logDirectory = activitySummaryService.GetLogDirectory();
+		if (!Directory.Exists(logDirectory))
+		{
+			MessageBox.Show(
+				"No activity log folder exists yet.",
+				"Generate Activity Summary",
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Information);
+			return;
+		}
+
+		using var dialog = new OpenFileDialog
+		{
+			Title = "Select activity log to summarise",
+			InitialDirectory = logDirectory,
+			Filter = "Log files (*.log)|*.log|All files (*.*)|*.*",
+			CheckFileExists = true,
+			CheckPathExists = true,
+			Multiselect = false,
+			RestoreDirectory = true,
+		};
+
+		if (dialog.ShowDialog() != DialogResult.OK)
+			return;
+
+		await GenerateSummaryWithFeedbackAsync(dialog.FileName, showSuccessMessage: true);
+	}
+
+	private async Task GeneratePreviousDaySummaryOnStartupAsync()
+	{
+		var result = await activitySummaryService.GeneratePreviousDaySummaryIfMissingAsync();
+		switch (result.Status)
+		{
+			case ActivitySummaryService.SummaryGenerationStatus.Success:
+				_logger.LogInformation($"Previous-day activity summary generated: {result.OutputPath}");
+				break;
+			case ActivitySummaryService.SummaryGenerationStatus.AlreadyExists:
+			case ActivitySummaryService.SummaryGenerationStatus.NoPreviousDayLog:
+			case ActivitySummaryService.SummaryGenerationStatus.MissingOutputDirectory:
+				_logger.LogDebug(result.Message);
+				break;
+			case ActivitySummaryService.SummaryGenerationStatus.MissingLog:
+			case ActivitySummaryService.SummaryGenerationStatus.Failed:
+				_logger.LogWarning($"Previous-day summary was not generated: {result.Message}");
+				break;
+		}
+	}
+
+	private async Task GenerateSummaryWithFeedbackAsync(string logPath, bool showSuccessMessage)
+	{
+		try
+		{
+			UseWaitCursor = true;
+			var result = await activitySummaryService.GenerateSummaryAsync(logPath);
+
+			if (result.Status == ActivitySummaryService.SummaryGenerationStatus.AlreadyExists)
+			{
+				var replaceResult = MessageBox.Show(
+					$"A summary already exists for this log:\n{result.OutputPath}\n\nReplace it?",
+					"Generate Activity Summary",
+					MessageBoxButtons.YesNo,
+					MessageBoxIcon.Question,
+					MessageBoxDefaultButton.Button2);
+
+				if (replaceResult == DialogResult.Yes)
+					result = await activitySummaryService.GenerateSummaryAsync(logPath, overwriteExisting: true);
+			}
+
+			switch (result.Status)
+			{
+				case ActivitySummaryService.SummaryGenerationStatus.Success:
+					if (showSuccessMessage)
+					{
+						MessageBox.Show(
+							$"Activity summary written to:\n{result.OutputPath}",
+							"Generate Activity Summary",
+							MessageBoxButtons.OK,
+							MessageBoxIcon.Information);
+					}
+					break;
+				case ActivitySummaryService.SummaryGenerationStatus.AlreadyExists:
+					break;
+				case ActivitySummaryService.SummaryGenerationStatus.MissingOutputDirectory:
+					MessageBox.Show(
+						"Set Activity Summary Output Folder in Settings before generating summaries.",
+						"Generate Activity Summary",
+						MessageBoxButtons.OK,
+						MessageBoxIcon.Information);
+					break;
+				case ActivitySummaryService.SummaryGenerationStatus.MissingLog:
+				case ActivitySummaryService.SummaryGenerationStatus.NoPreviousDayLog:
+					MessageBox.Show(
+						result.Message,
+						"Generate Activity Summary",
+						MessageBoxButtons.OK,
+						MessageBoxIcon.Information);
+					break;
+				case ActivitySummaryService.SummaryGenerationStatus.Failed:
+					MessageBox.Show(
+						$"Failed to generate summary.\n\n{result.Message}",
+						"Generate Activity Summary",
+						MessageBoxButtons.OK,
+						MessageBoxIcon.Error);
+					break;
+			}
+		}
+		finally
+		{
+			UseWaitCursor = false;
 		}
 	}
 

--- a/WindowsActivityLogger/MainForm.cs
+++ b/WindowsActivityLogger/MainForm.cs
@@ -10,11 +10,15 @@ namespace WindowsActivityLogger;
 
 public partial class MainForm : Form
 {
+	private const int SummaryCheckIntervalMilliseconds = 60 * 60 * 1000;
+
 	private Timer captureTimer = null!;
 	private Timer clearTimer = null!;
 	private Timer activityTimer = null!;
+	private Timer summaryTimer = null!;
 	private int captureInterval;
 	private bool isSessionLocked;
+	private int _isGeneratingAutomaticSummary;
 
 	private NotifyIcon notifyIcon = null!;
 	private readonly bool _postInstall;
@@ -50,7 +54,13 @@ public partial class MainForm : Form
 		clearTimer.Tick += (sender, e) => CleanOldScreenshots();
 		clearTimer.Start();
 
+		summaryTimer = new Timer();
+		summaryTimer.Interval = SummaryCheckIntervalMilliseconds;
+		summaryTimer.Tick += SummaryTimer_Tick;
+		summaryTimer.Start();
+
 		_logger.LogInformation($"Clear timer set to {config.CleanupIntervalHours} hours");
+		_logger.LogInformation("Activity summary auto-check timer set to 1 hour");
 
 		// Hide form on startup
 		this.WindowState = FormWindowState.Minimized;
@@ -71,6 +81,8 @@ public partial class MainForm : Form
 			clearTimer?.Dispose();
 			activityTimer?.Stop();
 			activityTimer?.Dispose();
+			summaryTimer?.Stop();
+			summaryTimer?.Dispose();
 			activityLoggingService.Flush(); // write any buffered lines before exit
 			components?.Dispose();
 		}
@@ -134,7 +146,7 @@ public partial class MainForm : Form
 				ToolTipIcon.Info);
 		}
 
-		_ = GeneratePreviousDaySummaryOnStartupAsync();
+		_ = RunAutomaticSummaryGenerationAsync();
 	}
 
 	private void Configure()
@@ -295,13 +307,23 @@ public partial class MainForm : Form
 		await GenerateSummaryWithFeedbackAsync(dialog.FileName, showSuccessMessage: true);
 	}
 
-	private async Task GeneratePreviousDaySummaryOnStartupAsync()
+	private async void SummaryTimer_Tick(object? sender, EventArgs e)
 	{
+		await RunAutomaticSummaryGenerationAsync();
+	}
+
+	private async Task RunAutomaticSummaryGenerationAsync()
+	{
+		if (Interlocked.Exchange(ref _isGeneratingAutomaticSummary, 1) == 1)
+			return;
+
+		try
+		{
 		var result = await activitySummaryService.GeneratePreviousDaySummaryIfMissingAsync();
 		switch (result.Status)
 		{
 			case ActivitySummaryService.SummaryGenerationStatus.Success:
-				_logger.LogInformation($"Previous-day activity summary generated: {result.OutputPath}");
+				_logger.LogInformation($"Automatic activity summary generated: {result.OutputPath}");
 				break;
 			case ActivitySummaryService.SummaryGenerationStatus.AlreadyExists:
 			case ActivitySummaryService.SummaryGenerationStatus.NoPreviousDayLog:
@@ -310,8 +332,13 @@ public partial class MainForm : Form
 				break;
 			case ActivitySummaryService.SummaryGenerationStatus.MissingLog:
 			case ActivitySummaryService.SummaryGenerationStatus.Failed:
-				_logger.LogWarning($"Previous-day summary was not generated: {result.Message}");
+				_logger.LogWarning($"Automatic summary was not generated: {result.Message}");
 				break;
+		}
+		}
+		finally
+		{
+			Interlocked.Exchange(ref _isGeneratingAutomaticSummary, 0);
 		}
 	}
 

--- a/WindowsActivityLogger/MainForm.cs
+++ b/WindowsActivityLogger/MainForm.cs
@@ -38,7 +38,7 @@ public partial class MainForm : Form
 		cleanupService = cleanup ?? new CleanupService(config, _logger);
 		activityLoggingService = new ActivityLoggingService(config, _logger);
 		activitySummaryService = new ActivitySummaryService(config, _logger);
-		
+
 		InitializeComponent();
 		Configure();
 
@@ -48,7 +48,7 @@ public partial class MainForm : Form
 		// Clean up old screenshots on startup
 		CleanOldScreenshots();
 
-		 // Initialize and start the clear timer
+		// Initialize and start the clear timer
 		clearTimer = new Timer();
 		clearTimer.Interval = config.CleanupIntervalHours * 60 * 60 * 1000; // Convert hours to milliseconds
 		clearTimer.Tick += (sender, e) => CleanOldScreenshots();
@@ -111,14 +111,14 @@ public partial class MainForm : Form
 		notifyIcon.ContextMenuStrip.Items.Add("Open Activity Log", null, OpenActivityLog);
 		notifyIcon.ContextMenuStrip.Items.Add("Generate Activity Summary...", null, GenerateActivitySummaryAsync);
 		notifyIcon.ContextMenuStrip.Items.Add("Clean Old Screenshots", null, OnCleanClick);
-		
+
 		// Add uninstall option if application is installed
 		if (SelfInstaller.IsInstalled() && SelfInstaller.IsRunningFromInstallLocation())
 		{
 			notifyIcon.ContextMenuStrip.Items.Add("-"); // Separator
 			notifyIcon.ContextMenuStrip.Items.Add("Uninstall", null, OnUninstallClick);
 		}
-		
+
 		notifyIcon.ContextMenuStrip.Items.Add("-"); // Separator
 		notifyIcon.ContextMenuStrip.Items.Add("Exit", null, Exit);
 
@@ -159,20 +159,20 @@ public partial class MainForm : Form
 			MessageBox.Show("Invalid capture interval. Please check your settings.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 			return;
 		}
-		
+
 		if (captureTimer != null)
 		{
 			captureTimer.Stop();
 			captureTimer.Tick -= CaptureTimer_Tick;
 		}
-		
+
 		captureTimer = new Timer
 		{
 			Interval = captureInterval * 1000
 		};
 		captureTimer.Tick += CaptureTimer_Tick;
 		captureTimer.Start();
-		
+
 		_logger.LogInformation($"Capture timer configured with {captureInterval} second interval");
 
 		// Activity logging — separate timer, independent of screenshot interval
@@ -319,22 +319,22 @@ public partial class MainForm : Form
 
 		try
 		{
-		var result = await activitySummaryService.GeneratePreviousDaySummaryIfMissingAsync();
-		switch (result.Status)
-		{
-			case ActivitySummaryService.SummaryGenerationStatus.Success:
-				_logger.LogInformation($"Automatic activity summary generated: {result.OutputPath}");
-				break;
-			case ActivitySummaryService.SummaryGenerationStatus.AlreadyExists:
-			case ActivitySummaryService.SummaryGenerationStatus.NoPreviousDayLog:
-			case ActivitySummaryService.SummaryGenerationStatus.MissingOutputDirectory:
-				_logger.LogDebug(result.Message);
-				break;
-			case ActivitySummaryService.SummaryGenerationStatus.MissingLog:
-			case ActivitySummaryService.SummaryGenerationStatus.Failed:
-				_logger.LogWarning($"Automatic summary was not generated: {result.Message}");
-				break;
-		}
+			var result = await activitySummaryService.GeneratePreviousDaySummaryIfMissingAsync();
+			switch (result.Status)
+			{
+				case ActivitySummaryService.SummaryGenerationStatus.Success:
+					_logger.LogInformation($"Automatic activity summary generated: {result.OutputPath}");
+					break;
+				case ActivitySummaryService.SummaryGenerationStatus.AlreadyExists:
+				case ActivitySummaryService.SummaryGenerationStatus.NoPreviousDayLog:
+				case ActivitySummaryService.SummaryGenerationStatus.MissingOutputDirectory:
+					_logger.LogDebug(result.Message);
+					break;
+				case ActivitySummaryService.SummaryGenerationStatus.MissingLog:
+				case ActivitySummaryService.SummaryGenerationStatus.Failed:
+					_logger.LogWarning($"Automatic summary was not generated: {result.Message}");
+					break;
+			}
 		}
 		finally
 		{
@@ -466,7 +466,7 @@ public partial class MainForm : Form
 	private void OnCleanClick(object? sender, EventArgs e)
 	{
 		int deleted = CleanOldScreenshots();
-		MessageBox.Show($"Old screenshots (older than {config.ClearDays} days) have been removed. Deleted {deleted} folder(s).", 
+		MessageBox.Show($"Old screenshots (older than {config.ClearDays} days) have been removed. Deleted {deleted} folder(s).",
 			"Cleanup Complete", MessageBoxButtons.OK, MessageBoxIcon.Information);
 	}
 
@@ -482,11 +482,12 @@ public partial class MainForm : Form
 		return dl;
 	}
 
-	private void OnUninstallClick(object? sender, EventArgs e)	{
+	private void OnUninstallClick(object? sender, EventArgs e)
+	{
 		// Safety check
 		if (!SelfInstaller.IsInstalled() || !SelfInstaller.IsRunningFromInstallLocation())
 		{
-			MessageBox.Show("Uninstall is only available when running from the installed location.", 
+			MessageBox.Show("Uninstall is only available when running from the installed location.",
 				"Uninstall Not Available", MessageBoxButtons.OK, MessageBoxIcon.Information);
 			return;
 		}
@@ -512,7 +513,7 @@ public partial class MainForm : Form
 			}
 			catch (Exception ex)
 			{
-				MessageBox.Show($"Failed to start uninstallation: {ex.Message}", 
+				MessageBox.Show($"Failed to start uninstallation: {ex.Message}",
 					"Uninstall Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 			}
 		}

--- a/WindowsActivityLogger/Services/ActivitySummaryService.cs
+++ b/WindowsActivityLogger/Services/ActivitySummaryService.cs
@@ -39,11 +39,16 @@ public sealed class ActivitySummaryService
 		if (File.Exists(outputPath) && !overwriteExisting)
 			return SummaryGenerationResult.AlreadyExists(logPath, outputPath);
 
+		string? backupPath = null;
+
 		try
 		{
 			Directory.CreateDirectory(outputDirectory);
 			if (overwriteExisting && File.Exists(outputPath))
-				File.Delete(outputPath);
+			{
+				backupPath = Path.Combine(outputDirectory, Path.GetRandomFileName() + ".bak");
+				File.Move(outputPath, backupPath, overwrite: false);
+			}
 
 			var processorPath = ResolveProcessorPath();
 			var args = new[]
@@ -61,6 +66,7 @@ public sealed class ActivitySummaryService
 
 			if (execution.ExitCode != 0)
 			{
+				RestoreBackupIfNeeded(backupPath, outputPath);
 				var error = string.IsNullOrWhiteSpace(execution.StandardError)
 					? $"ActivityLogProcessor exited with code {execution.ExitCode}."
 					: execution.StandardError.Trim();
@@ -70,16 +76,20 @@ public sealed class ActivitySummaryService
 
 			if (!File.Exists(outputPath))
 			{
+				RestoreBackupIfNeeded(backupPath, outputPath);
 				const string missingOutputMessage = "Summary generation completed but no output file was created.";
 				_logger.LogError(missingOutputMessage);
 				return SummaryGenerationResult.Failed(missingOutputMessage, logPath, outputPath);
 			}
+
+			DeleteBackupIfNeeded(backupPath);
 
 			_logger.LogInformation($"Activity summary written to '{outputPath}'");
 			return SummaryGenerationResult.Success(logPath, outputPath);
 		}
 		catch (Exception ex)
 		{
+			RestoreBackupIfNeeded(backupPath, outputPath);
 			_logger.LogException(ex, "Activity summary generation");
 			return SummaryGenerationResult.Failed(ex.Message, logPath, outputPath);
 		}
@@ -126,17 +136,33 @@ public sealed class ActivitySummaryService
 		if (File.Exists(expectedPath))
 			return expectedPath;
 
-		return Directory.EnumerateFiles(logDirectory, "*.log")
+		return Directory.EnumerateFiles(logDirectory, "????-??-??.log")
 			.Select(path => new
 			{
 				Path = path,
-				Date = TryGetLogDate(path) ?? new FileInfo(path).LastWriteTime.Date,
+				Date = TryGetLogDate(path),
 			})
-			.Where(file => file.Date < now.Date)
-			.OrderByDescending(file => file.Date)
-			.ThenByDescending(file => new FileInfo(file.Path).LastWriteTimeUtc)
+			.Where(file => file.Date.HasValue && file.Date.Value < now.Date)
+			.OrderByDescending(file => file.Date!.Value)
 			.Select(file => file.Path)
 			.FirstOrDefault();
+	}
+
+	private static void RestoreBackupIfNeeded(string? backupPath, string outputPath)
+	{
+		if (string.IsNullOrEmpty(backupPath) || !File.Exists(backupPath))
+			return;
+
+		if (File.Exists(outputPath))
+			File.Delete(outputPath);
+
+		File.Move(backupPath, outputPath, overwrite: false);
+	}
+
+	private static void DeleteBackupIfNeeded(string? backupPath)
+	{
+		if (!string.IsNullOrEmpty(backupPath) && File.Exists(backupPath))
+			File.Delete(backupPath);
 	}
 
 	private static DateTime? TryGetLogDate(string path)

--- a/WindowsActivityLogger/Services/ActivitySummaryService.cs
+++ b/WindowsActivityLogger/Services/ActivitySummaryService.cs
@@ -1,6 +1,4 @@
 using System.Diagnostics;
-using System.Reflection;
-using WindowsActivityLogger.Installation;
 
 namespace WindowsActivityLogger.Services;
 
@@ -154,31 +152,11 @@ public sealed class ActivitySummaryService
 		if (_processorPathResolver is not null)
 			return _processorPathResolver();
 
-		var installedPath = SelfInstaller.InstalledProcessorPath;
-		if (File.Exists(installedPath))
-			return installedPath;
+		var processorPath = Path.Combine(AppContext.BaseDirectory, "ActivityLogProcessor.exe");
+		if (!File.Exists(processorPath))
+			throw new FileNotFoundException($"ActivityLogProcessor.exe was not found in the running executable directory: {AppContext.BaseDirectory}");
 
-		var localPath = Path.Combine(AppContext.BaseDirectory, "ActivityLogProcessor.exe");
-		if (File.Exists(localPath))
-			return localPath;
-
-		var extractedPath = Path.Combine(
-			Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-			ApplicationConstants.ApplicationName,
-			"Tools",
-			"ActivityLogProcessor.exe");
-
-		if (File.Exists(extractedPath))
-			return extractedPath;
-
-		Directory.CreateDirectory(Path.GetDirectoryName(extractedPath)!);
-		using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ActivityLogProcessor.exe");
-		if (stream is null)
-			throw new FileNotFoundException("Embedded ActivityLogProcessor.exe resource was not found.");
-
-		using var output = new FileStream(extractedPath, FileMode.Create, FileAccess.Write, FileShare.Read);
-		stream.CopyTo(output);
-		return extractedPath;
+		return processorPath;
 	}
 
 	private static async Task<ProcessExecutionResult> RunProcessAsync(string fileName, IReadOnlyList<string> arguments, CancellationToken cancellationToken)

--- a/WindowsActivityLogger/Services/ActivitySummaryService.cs
+++ b/WindowsActivityLogger/Services/ActivitySummaryService.cs
@@ -1,0 +1,246 @@
+using System.Diagnostics;
+using System.Reflection;
+using WindowsActivityLogger.Installation;
+
+namespace WindowsActivityLogger.Services;
+
+public sealed class ActivitySummaryService
+{
+	private readonly AppConfiguration _config;
+	private readonly ILogger _logger;
+	private readonly Func<string>? _processorPathResolver;
+	private readonly Func<string, IReadOnlyList<string>, CancellationToken, Task<ProcessExecutionResult>>? _processRunner;
+
+	public ActivitySummaryService(
+		AppConfiguration config,
+		ILogger logger,
+		Func<string>? processorPathResolver = null,
+		Func<string, IReadOnlyList<string>, CancellationToken, Task<ProcessExecutionResult>>? processRunner = null)
+	{
+		_config = config ?? throw new ArgumentNullException(nameof(config));
+		_logger = logger ?? throw new ArgumentNullException(nameof(logger));
+		_processorPathResolver = processorPathResolver;
+		_processRunner = processRunner;
+	}
+
+	public string GetLogDirectory() => _config.GetEffectiveSavePath();
+
+	public async Task<SummaryGenerationResult> GenerateSummaryAsync(string logPath, bool overwriteExisting = false, CancellationToken cancellationToken = default)
+	{
+		if (string.IsNullOrWhiteSpace(logPath))
+			return SummaryGenerationResult.Failed("A log file path is required.");
+
+		if (!File.Exists(logPath))
+			return SummaryGenerationResult.MissingLog(logPath);
+
+		var outputDirectory = GetConfiguredOutputDirectory();
+		if (outputDirectory is null)
+			return SummaryGenerationResult.MissingOutputDirectory();
+
+		var outputPath = GetSummaryOutputPath(logPath, outputDirectory);
+		if (File.Exists(outputPath) && !overwriteExisting)
+			return SummaryGenerationResult.AlreadyExists(logPath, outputPath);
+
+		try
+		{
+			Directory.CreateDirectory(outputDirectory);
+			if (overwriteExisting && File.Exists(outputPath))
+				File.Delete(outputPath);
+
+			var processorPath = ResolveProcessorPath();
+			var args = new[]
+			{
+				"--logpath",
+				logPath,
+				"--interval",
+				_config.ActivitySampleIntervalSeconds.ToString(),
+				"--out-dir",
+				outputDirectory,
+			};
+
+			_logger.LogInformation($"Generating activity summary for '{logPath}' → '{outputPath}'");
+			var execution = await (_processRunner ?? RunProcessAsync)(processorPath, args, cancellationToken);
+
+			if (execution.ExitCode != 0)
+			{
+				var error = string.IsNullOrWhiteSpace(execution.StandardError)
+					? $"ActivityLogProcessor exited with code {execution.ExitCode}."
+					: execution.StandardError.Trim();
+				_logger.LogError($"Activity summary generation failed: {error}");
+				return SummaryGenerationResult.Failed(error, logPath, outputPath);
+			}
+
+			if (!File.Exists(outputPath))
+			{
+				const string missingOutputMessage = "Summary generation completed but no output file was created.";
+				_logger.LogError(missingOutputMessage);
+				return SummaryGenerationResult.Failed(missingOutputMessage, logPath, outputPath);
+			}
+
+			_logger.LogInformation($"Activity summary written to '{outputPath}'");
+			return SummaryGenerationResult.Success(logPath, outputPath);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogException(ex, "Activity summary generation");
+			return SummaryGenerationResult.Failed(ex.Message, logPath, outputPath);
+		}
+	}
+
+	public async Task<SummaryGenerationResult> GeneratePreviousDaySummaryIfMissingAsync(DateTime? now = null, CancellationToken cancellationToken = default)
+	{
+		var previousDayLogPath = GetPreviousDayLogPath(now ?? DateTime.Now);
+		if (previousDayLogPath is null)
+			return SummaryGenerationResult.NoPreviousDayLog();
+
+		var outputDirectory = GetConfiguredOutputDirectory();
+		if (outputDirectory is null)
+			return SummaryGenerationResult.MissingOutputDirectory();
+
+		var outputPath = GetSummaryOutputPath(previousDayLogPath, outputDirectory);
+		if (File.Exists(outputPath))
+			return SummaryGenerationResult.AlreadyExists(previousDayLogPath, outputPath);
+
+		return await GenerateSummaryAsync(previousDayLogPath, cancellationToken: cancellationToken);
+	}
+
+	internal string? GetConfiguredOutputDirectory()
+	{
+		return string.IsNullOrWhiteSpace(_config.ActivitySummaryOutputDir)
+			? null
+			: _config.ActivitySummaryOutputDir.Trim();
+	}
+
+	internal string GetSummaryOutputPath(string logPath, string outputDirectory)
+	{
+		return Path.Combine(outputDirectory, Path.GetFileNameWithoutExtension(logPath) + ".md");
+	}
+
+	internal string? GetPreviousDayLogPath(DateTime now)
+	{
+		var logDirectory = GetLogDirectory();
+		if (!Directory.Exists(logDirectory))
+			return null;
+
+		var yesterday = now.Date.AddDays(-1);
+		var expectedName = yesterday.ToString("yyyy-MM-dd") + ".log";
+		var expectedPath = Path.Combine(logDirectory, expectedName);
+		if (File.Exists(expectedPath))
+			return expectedPath;
+
+		return Directory.EnumerateFiles(logDirectory, "*.log")
+			.Select(path => new
+			{
+				Path = path,
+				Date = TryGetLogDate(path) ?? new FileInfo(path).LastWriteTime.Date,
+			})
+			.Where(file => file.Date < now.Date)
+			.OrderByDescending(file => file.Date)
+			.ThenByDescending(file => new FileInfo(file.Path).LastWriteTimeUtc)
+			.Select(file => file.Path)
+			.FirstOrDefault();
+	}
+
+	private static DateTime? TryGetLogDate(string path)
+	{
+		var fileName = Path.GetFileNameWithoutExtension(path);
+		return DateTime.TryParseExact(fileName, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var parsed)
+			? parsed.Date
+			: null;
+	}
+
+	private string ResolveProcessorPath()
+	{
+		if (_processorPathResolver is not null)
+			return _processorPathResolver();
+
+		var installedPath = SelfInstaller.InstalledProcessorPath;
+		if (File.Exists(installedPath))
+			return installedPath;
+
+		var localPath = Path.Combine(AppContext.BaseDirectory, "ActivityLogProcessor.exe");
+		if (File.Exists(localPath))
+			return localPath;
+
+		var extractedPath = Path.Combine(
+			Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+			ApplicationConstants.ApplicationName,
+			"Tools",
+			"ActivityLogProcessor.exe");
+
+		if (File.Exists(extractedPath))
+			return extractedPath;
+
+		Directory.CreateDirectory(Path.GetDirectoryName(extractedPath)!);
+		using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ActivityLogProcessor.exe");
+		if (stream is null)
+			throw new FileNotFoundException("Embedded ActivityLogProcessor.exe resource was not found.");
+
+		using var output = new FileStream(extractedPath, FileMode.Create, FileAccess.Write, FileShare.Read);
+		stream.CopyTo(output);
+		return extractedPath;
+	}
+
+	private static async Task<ProcessExecutionResult> RunProcessAsync(string fileName, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+	{
+		using var process = new Process
+		{
+			StartInfo = new ProcessStartInfo
+			{
+				FileName = fileName,
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true,
+				CreateNoWindow = true,
+			}
+		};
+
+		foreach (var argument in arguments)
+			process.StartInfo.ArgumentList.Add(argument);
+
+		process.Start();
+		var stdOutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+		var stdErrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+		await process.WaitForExitAsync(cancellationToken);
+		return new ProcessExecutionResult(process.ExitCode, await stdOutTask, await stdErrTask);
+	}
+
+	public sealed record ProcessExecutionResult(int ExitCode, string StandardOutput, string StandardError);
+
+	public sealed record SummaryGenerationResult(
+		SummaryGenerationStatus Status,
+		string Message,
+		string? LogPath = null,
+		string? OutputPath = null)
+	{
+		public bool Succeeded => Status == SummaryGenerationStatus.Success;
+
+		public static SummaryGenerationResult Success(string logPath, string outputPath)
+			=> new(SummaryGenerationStatus.Success, "Summary generated.", logPath, outputPath);
+
+		public static SummaryGenerationResult AlreadyExists(string logPath, string outputPath)
+			=> new(SummaryGenerationStatus.AlreadyExists, "Summary already exists.", logPath, outputPath);
+
+		public static SummaryGenerationResult MissingOutputDirectory()
+			=> new(SummaryGenerationStatus.MissingOutputDirectory, "Activity summary output directory is not configured.");
+
+		public static SummaryGenerationResult MissingLog(string logPath)
+			=> new(SummaryGenerationStatus.MissingLog, "Selected activity log file was not found.", logPath);
+
+		public static SummaryGenerationResult NoPreviousDayLog()
+			=> new(SummaryGenerationStatus.NoPreviousDayLog, "No previous-day activity log was found.");
+
+		public static SummaryGenerationResult Failed(string message, string? logPath = null, string? outputPath = null)
+			=> new(SummaryGenerationStatus.Failed, message, logPath, outputPath);
+	}
+
+	public enum SummaryGenerationStatus
+	{
+		Success,
+		AlreadyExists,
+		MissingOutputDirectory,
+		MissingLog,
+		NoPreviousDayLog,
+		Failed,
+	}
+}

--- a/WindowsActivityLogger/WindowsActivityLogger.csproj
+++ b/WindowsActivityLogger/WindowsActivityLogger.csproj
@@ -84,4 +84,13 @@
 		<Message Text="ActivityLogProcessor published and embedded." Importance="high" />
 	</Target>
 
+	<Target Name="CopyActivityLogProcessorToOutput" AfterTargets="Build" DependsOnTargets="PublishActivityLogProcessor"
+	        Inputs="$(ActivityProcessorExe)"
+	        Outputs="$(OutDir)ActivityLogProcessor.exe">
+		<Copy SourceFiles="$(ActivityProcessorExe)"
+		      DestinationFiles="$(OutDir)ActivityLogProcessor.exe"
+		      SkipUnchangedFiles="true" />
+		<Message Text="ActivityLogProcessor copied to output: $(OutDir)ActivityLogProcessor.exe" Importance="high" />
+	</Target>
+
 </Project>


### PR DESCRIPTION
## Summary
Add activity summary generation to the tray menu and automatically backfill missing summaries while the app remains running, using the co-located `ActivityLogProcessor.exe` from the main app output directory.

## Changes
- add `ActivitySummaryService` to select eligible log files and run `ActivityLogProcessor.exe` into `activitySummaryOutputDir`
- resolve the processor executable only from the current running executable directory (`AppContext.BaseDirectory`)
- add a tray menu action that lets the user choose a log file from the log folder and generate a summary manually
- prompt to replace an existing summary file when manual generation targets an existing markdown output
- automatically generate a summary on startup for yesterday's log, or the latest available log before today when yesterday is missing, while still skipping if the summary already exists
- add an hourly automatic summary check so long-running Windows sessions continue to backfill summaries after day rollover without requiring an app restart
- guard against overlapping automatic summary runs in the WinForms host
- filter markdown summary documents so apps with less than 2 minutes total time are excluded from the generated summary tables
- copy `ActivityLogProcessor.exe` into the main app output directory during build so runtime resolution from the app directory works in Debug output
- add unit tests for output naming, previous-log selection, missing output directory handling, processor invocation, overwrite behavior, and markdown filtering

## Validation
- `dotnet test WindowsScreenLogger.sln`
- `dotnet build WindowsActivityLogger/WindowsActivityLogger.csproj -c Debug -o .tmp/debug-main-out-fix`
- verified `.tmp/debug-main-out-fix/WindowsActivityLogger.exe` and `.tmp/debug-main-out-fix/ActivityLogProcessor.exe` are present side by side

## Review Notes
- automatic generation remains non-overwrite and only backfills missing summaries
- manual generation is the only path that prompts to replace an existing summary file
- full default-output test runs can be blocked locally if the running `WindowsActivityLogger.exe` locks the default Debug output path